### PR TITLE
Arreglado skins de Minecraft Online

### DIFF
--- a/app/assets/js/scripts/landing.js
+++ b/app/assets/js/scripts/landing.js
@@ -168,7 +168,7 @@ function updateSelectedAccount(authUser){
             username = authUser.displayName
         }
         if(authUser.uuid != null){
-            document.getElementById('avatarContainer').style.backgroundImage = `url('https://mc-heads.net/body/${authUser.uuid}/right')`
+            document.getElementById('avatarContainer').style.backgroundImage = `url('https://mc-heads.net/head/${authUser.displayName}/40')`
         }
     }
     user_text.innerHTML = username

--- a/app/assets/js/scripts/overlay.js
+++ b/app/assets/js/scripts/overlay.js
@@ -324,7 +324,7 @@ function populateAccountListings(){
     let htmlString = ''
     for(let i=0; i<accounts.length; i++){
         htmlString += `<button class="accountListing" uuid="${accounts[i].uuid}" ${i===0 ? 'selected' : ''}>
-            <img src="https://mc-heads.net/head/${accounts[i].uuid}/40">
+            <img src="https://mc-heads.net/head/${accounts[i].displayName}/40">
             <div class="accountListingName">${accounts[i].displayName}</div>
         </button>`
     }

--- a/app/assets/js/scripts/settings.js
+++ b/app/assets/js/scripts/settings.js
@@ -659,7 +659,7 @@ function populateAuthAccounts(){
 
         const accHtml = `<div class="settingsAuthAccount" uuid="${acc.uuid}">
             <div class="settingsAuthAccountLeft">
-                <img class="settingsAuthAccountImage" alt="${acc.displayName}" src="https://mc-heads.net/body/${acc.uuid}/60">
+                <img class="settingsAuthAccountImage" alt="${acc.displayName}" src="https://mc-heads.net/body/${acc.displayName}/60">
             </div>
             <div class="settingsAuthAccountRight">
                 <div class="settingsAuthAccountDetails">

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -71,7 +71,7 @@
                 </div>
 
                 <div class="settingsCurrentAccounts" id="settingsCurrentMojangAccounts">
-                    <!-- Mojang auth accounts populated here. -->
+                    <!-- VI Software auth accounts populated here. -->
                 </div>
             </div>
             <div class="settingsAuthAccountTypeContainer">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vis-launcher",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "productName": "VI Software Launcher",
   "description": "VI Software Launcher",
   "author": "VI Software",


### PR DESCRIPTION
Ahora se requiere el nombre de la cuenta en lugar de la UUID al utilizar el api de mc-heads, así se siguen cargando las skins del Minecraft online